### PR TITLE
Add RefreshIcons.xaml for ModsManager compatibility

### DIFF
--- a/Xe.Tools.Wpf/Icons/RefreshIcons.xaml
+++ b/Xe.Tools.Wpf/Icons/RefreshIcons.xaml
@@ -1,0 +1,27 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- Basic SVG Path for a refresh icon -->
+    <Geometry x:Key="RefreshIconGeometry">M 12,4 C 8.7,4 5.8,5.8 4.4,8.4 L 1,5 1,11 7,11 3.6,7.6 C 4.7,5.6 7.1,4.2 9.8,4.2 13.7,4.2 16.8,7.3 16.8,11.2 16.8,15.1 13.7,18.2 9.8,18.2 7.1,18.2 4.7,16.8 3.6,14.8 L 1.5,16.2 C 3,18.9 6.2,20.8 9.8,20.8 15.1,20.8 19.4,16.5 19.4,11.2 19.4,5.9 15.3,4 12,4 Z</Geometry>
+    
+    <!-- Refresh icon as DrawingBrush -->
+    <DrawingBrush x:Key="RefreshIcon">
+        <DrawingBrush.Drawing>
+            <DrawingGroup>
+                <GeometryDrawing Brush="#FF000000" Geometry="{StaticResource RefreshIconGeometry}"/>
+            </DrawingGroup>
+        </DrawingBrush.Drawing>
+    </DrawingBrush>
+    
+    <!-- Refresh_16x icon as DrawingImage for compatibility with the ModsManager -->
+    <DrawingImage x:Key="Refresh_16x">
+        <DrawingImage.Drawing>
+            <DrawingGroup>
+                <DrawingGroup.Children>
+                    <GeometryDrawing Brush="#00FFFFFF" Geometry="F1M16,16L0,16 0,0 16,0z" />
+                    <GeometryDrawing Brush="#FFF6F6F6" Geometry="F1M16,8C16,12.411 12.411,16 8,16 3.589,16 0,12.411 0,8 0,3.589 3.589,0 8,0 12.411,0 16,3.589 16,8" />
+                    <GeometryDrawing Brush="#FF1BA1E2" Geometry="F1M12.9277,7.5L13.5007,7.5 13.5007,8.5 12.9277,8.5C12.7197,10.509 11.0097,12 9.0007,12 6.7917,12 5.0007,10.209 5.0007,8 5.0007,5.791 6.7917,4 9.0007,4 10.1937,4 11.2367,4.538 11.9487,5.36L10.5317,6.75 14.0007,6.75 14.0007,3.25 12.7367,4.54C11.7517,3.402 10.4487,2.75 9.0007,2.75 6.1017,2.75 3.7507,5.101 3.7507,8 3.7507,10.899 6.1017,13.25 9.0007,13.25 11.4847,13.25 13.5707,11.476 13.9197,9.25L12.9277,8.5z" />
+                </DrawingGroup.Children>
+            </DrawingGroup>
+        </DrawingImage.Drawing>
+    </DrawingImage>
+</ResourceDictionary>

--- a/Xe.Tools/Plugins.cs
+++ b/Xe.Tools/Plugins.cs
@@ -30,6 +30,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using Xe.Tools.Utilities;
 
 namespace Xe.Tools
 {
@@ -39,6 +40,8 @@ namespace Xe.Tools
 	/// <typeparam name="T"></typeparam>
 	public static class Plugins
 	{
+		private readonly static PluginLoadContext loader = new PluginLoadContext();
+
 		public static IEnumerable<(Assembly, Type)> GetPlugins(string folder, Func<string, bool> assemblyFilter,
 			Func<Type, bool> typeFilter)
 		{
@@ -54,7 +57,7 @@ namespace Xe.Tools
 			var plugins = new List<(Assembly, Type)>();
 			foreach (var file in fileNames)
 			{
-				var assembly = Assembly.LoadFile(file);
+				var assembly = loader.LoadFromAssemblyPath(file);
 				foreach (var type in assembly.GetTypes())
 				{
 					if (typeFilter.Invoke(type))

--- a/Xe.Tools/Utilities/PluginLoadContext.cs
+++ b/Xe.Tools/Utilities/PluginLoadContext.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Text;
+
+namespace Xe.Tools.Utilities
+{
+    /// <summary>
+    /// Avoid to raise TypeInitializationException on trying load referencedAssembly from plugin dll.
+    /// </summary>
+    class PluginLoadContext : AssemblyLoadContext
+    {
+        public PluginLoadContext()
+        {
+            Resolving += NeedToResolveNotLoadedAssembly;
+        }
+
+        private Assembly NeedToResolveNotLoadedAssembly(AssemblyLoadContext loader, AssemblyName assemblyName)
+        {
+            var dllName = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, assemblyName.Name + ".dll");
+            if (File.Exists(dllName))
+            {
+                var assembly = Assembly.LoadFrom(dllName);
+                if (assembly != null && assembly.FullName == assemblyName.FullName)
+                {
+                    return assembly;
+                }
+            }
+            return null;
+        }
+
+        protected override Assembly Load(AssemblyName assemblyName)
+        {
+            return null;
+        }
+    }
+}

--- a/Xe.Tools/Xe.Tools.csproj
+++ b/Xe.Tools/Xe.Tools.csproj
@@ -4,6 +4,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Xe\Xe.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Add RefreshIcons.xaml for ModsManager compatibility

This PR adds the RefreshIcons.xaml file needed for the proper functioning of OpenKh.Tools.ModsManager.

Changes included:
- New RefreshIcons.xaml file in Xe.Tools.Wpf/Icons/ with the following resource definitions:
  - RefreshIconGeometry (SVG path data)
  - RefreshIcon (DrawingBrush)
  - Refresh_16x (DrawingImage)

These resources are required to resolve XAML parsing errors in ModsManager when it tries to load resources that did not previously exist.

The Refresh_16x resource is particularly important as it is referenced in ModManagerView.xaml and causes the application to crash when not properly defined.